### PR TITLE
Fix a bug with the initial load not disabling the button.

### DIFF
--- a/app/manifest.json
+++ b/app/manifest.json
@@ -1,6 +1,6 @@
 {
     "name": "Disable GitHub Merge",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "manifest_version": 2,
     "description": "Disables the GitHub merge button for user configurable target branches",
     "icons": {

--- a/app/scripts/contentscript.js
+++ b/app/scripts/contentscript.js
@@ -51,7 +51,9 @@
     var config = {childList: true};
     var parent = $('#partial-pull-merging').parent()[0]
 
-    observer.observe(parent, config);
+    if(parent) {
+      observer.observe(parent, config);
+    };
   };
 
   function setupBindsFollowingPageLoad() {


### PR DESCRIPTION
If the `contentscript` initially on a page without a merge button an error would be thrown with the mutation observer and it would fail to properly handle page transitions.   Simply avoiding attempting to bind the mutation observer when no element is present resolves the issues.

Fixes #2 